### PR TITLE
Path error in case of Framework

### DIFF
--- a/TyphoonRestClient/Extras/Connections/TRCConnectionStub.m
+++ b/TyphoonRestClient/Extras/Connections/TRCConnectionStub.m
@@ -260,7 +260,7 @@
 
 NSString *TRCBundleFile(NSString *fileName)
 {
-    NSString *path = [[NSBundle bundleForClass:[TRCConnectionStub class]] pathForResource:fileName ofType:nil];
+    NSString *path = [[NSBundle mainBundle] pathForResource:fileName ofType:nil];
     if (path) {
         return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     } else {

--- a/TyphoonRestClient/Internal/SchemeFactory/TRCSchemeFactory.m
+++ b/TyphoonRestClient/Internal/SchemeFactory/TRCSchemeFactory.m
@@ -92,7 +92,7 @@
                       useCache:(BOOL)useCache
 {
     NSString *filePath = nil;
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *bundle = [NSBundle mainBundle];
 
     if ([object respondsToSelector:sel]) {
         NSString *(*impl)(id, SEL) = (NSString*(*)(id, SEL))[object methodForSelector:sel];
@@ -139,7 +139,7 @@
     for (NSString *formatExtension in formats) {
         NSString *fileNameToTest = [fileName stringByAppendingPathExtension:formatExtension];
         if ([self isSchemaExistsWithFilename:fileNameToTest]) {
-            NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+            NSBundle *bundle = [NSBundle mainBundle];
             return [[bundle bundlePath] stringByAppendingPathComponent:fileNameToTest];
         }
     }
@@ -227,7 +227,7 @@
     if (!_cachedFilenames || _shouldRecacheFilenames) {
         NSMutableSet *filenames = [NSMutableSet new];
 
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        NSBundle *bundle = [NSBundle mainBundle];
 
         NSArray *allFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[bundle bundlePath] error:nil];
 

--- a/TyphoonRestClientTests/TyphoonRestClient/TRCConverterTests.m
+++ b/TyphoonRestClientTests/TyphoonRestClient/TRCConverterTests.m
@@ -134,7 +134,7 @@
 
     if (name) {
         TRCSerializerJson *jsonSerializer = [TRCSerializerJson new];
-        NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:name ofType:nil];
+        NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:nil];
         result = [jsonSerializer responseSchemaDataFromData:[NSData dataWithContentsOfFile:path] dataProvider:self error:nil];
     }
     return result;

--- a/TyphoonRestClientTests/TyphoonRestClient/TRCSchemeTests.m
+++ b/TyphoonRestClientTests/TyphoonRestClient/TRCSchemeTests.m
@@ -33,7 +33,7 @@
 
 - (TRCSchema *)schemaWithName:(NSString *)name forRequest:(BOOL)request
 {
-    NSBundle *bundle = [NSBundle bundleForClass:[TRCSchemeTests class]];
+    NSBundle *bundle = [NSBundle mainBundle];
     NSString *schemePath = [bundle pathForResource:name ofType:nil];
 
 
@@ -496,7 +496,7 @@
 
 - (void)test_plist_scheme
 {
-    NSBundle *bundle = [NSBundle bundleForClass:[TRCSchemeTests class]];
+    NSBundle *bundle = [NSBundle mainBundle];
     NSString *schemePath = [bundle pathForResource:@"PropertyListSchema" ofType:@"plist"];
     
     TRCSerializerPlist *jsonSerializer = [TRCSerializerPlist new];


### PR DESCRIPTION
[NSBundle bundleForClass:] replaced with [NSBundle mainBundle] to fix the path errors in case of a framework.